### PR TITLE
Use canonical repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ It provides a simple API to get structs from HTTP API responses.
 
 It has been written using standard lib only so there are no dependencies.
 ## Installation
-`go get -u github.com/mtarnawa/gochan-desu`
+`go get -u github.com/mtarnawa/godesu`
 ## Usage
 See full example in `example/main.go`.
 


### PR DESCRIPTION
Otherwise people (me) end up trying to fix what looks like broken `go get`